### PR TITLE
Adds a Jenkinsfile to build automatically

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+@Library('freeagent') _
+
+freeagentGem( slack: [channel: '#rails-next'] ) {
+  stage("Setup Test") {
+  bash '''
+    sudo apt-get install libpq-dev
+    '''
+  }
+  stage("Test") {
+//   bundle.exec "rake"
+  }
+}


### PR DESCRIPTION
We've forked audited as we're trying to run/test FreeAgent against Edge rails. Given that the initial project is a hackday project, we haven't got time to investigate if we can fix upstream.

We need to add a Jenkinsfile so that we can rely on this in our FreeAgent gemfile and allow it to be built successfully.